### PR TITLE
luci-mod-admin-full: limit interface name length to 15 chars

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/iface_add.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/iface_add.lua
@@ -17,7 +17,12 @@ newnet = m:field(Value, "_netname", translate("Name of the new interface"),
 
 newnet:depends("_attach", "")
 newnet.default = arg[1] and "net_" .. arg[1]:gsub("[^%w_]+", "_")
-newnet.datatype = "uciname"
+newnet.datatype = "and(uciname,maxlength(15))"
+
+advice = m:field(DummyValue, "d1", translate("Note: interface name length"),
+	 translate("Maximum length of the name is 15 characters including " ..
+		"the automatic protocol/bridge prefix (br-, 6in4-, pppoe- etc.)"
+	))
 
 newproto = m:field(ListValue, "_netproto", translate("Protocol of the new interface"))
 


### PR DESCRIPTION
Limit the name of a new interface to 15 characters.
Add a note about the maximum length and the automatic protocol/bridge
prefixes (br-, 6in4-, pppoe- etc.).

Reference to:
https://dev.openwrt.org/ticket/20380
https://github.com/openwrt/luci/issues/507

There is a 15 character limit to the "real" interface name,
enforced both in the firewall and dnsmasq. The real interface name
includes the possible prefix "br-", "6in4-" etc. Example of an error:
  interface name `br-lan_protected' must be shorter than IFNAMSIZ (15)

Signed-off-by: Hannu Nyman <hannu.nyman@iki.fi>
(cherry picked from commit b1217c88c3566c1bd726bce9203da591af564bcf)